### PR TITLE
matcap-shader: Enable shadows for the Matcap pipeline

### DIFF
--- a/matcap-shader/MatcapShader.wlp
+++ b/matcap-shader/MatcapShader.wlp
@@ -1230,7 +1230,8 @@
             },
             "name": "Matcap",
             "depthTest": true,
-            "depthWrite": true
+            "depthWrite": true,
+            "castShadows": true
         },
         "53": {
             "link": {
@@ -1245,8 +1246,7 @@
             "version": [
                 0,
                 9,
-                0,
-                0
+                2
             ]
         },
         "scripting": {


### PR DESCRIPTION
Fixes shadows only being cast by the shader ball base:

![firefox_2022-10-12_16-07-17](https://user-images.githubusercontent.com/113025490/195365522-2deee808-e861-451b-a94a-4092eab34347.png)
