### PR TITLE
test: Add new waitForDependencies and isTextureStreamingIdle

### DIFF
--- a/hdri/test/index.js
+++ b/hdri/test/index.js
@@ -4,6 +4,7 @@ import {WasdControlsComponent} from '@wonderlandengine/components';
 /* wle:auto-imports:end */
 
 import {loadRuntime} from '@wonderlandengine/api';
+import {runScreenshotTest} from '../../test-utils.js';
 
 /* wle:auto-constants:start */
 const Constants = {
@@ -25,6 +26,9 @@ const RuntimeOptions = {
 };
 /* wle:auto-constants:end */
 
+RuntimeOptions.threads = false; /* Disabled for testing on any browser */
+RuntimeOptions.simd = false;
+
 const engine = await loadRuntime(Constants.RuntimeBaseName, RuntimeOptions);
 
 /* wle:auto-register:start */
@@ -32,16 +36,13 @@ engine.registerComponent(MouseLookComponent);
 engine.registerComponent(WasdControlsComponent);
 /* wle:auto-register:end */
 
-await engine.scene.load(`${Constants.ProjectName}.bin`);
-
 document.getElementById('version')?.remove();
 document.getElementById('ar-button')?.remove();
 document.getElementById('vr-button')?.remove();
 
-/* Dispatch scene ready event once the image is loaded.
- * This ensure the test suite takes a screenshot after
- * all resources are available. */
-
-await engine.imagesPromise;
-
-engine.scene.dispatchReadyEvent();
+await engine.loadMainScene({
+    url: `${Constants.ProjectName}.bin`,
+    waitForDependencies: true,
+    dispatchReadyEvent: false
+});
+runScreenshotTest(engine);

--- a/height-map/test/index.js
+++ b/height-map/test/index.js
@@ -7,19 +7,27 @@ import {HeightMap} from './../js/height-map.js';
 import {loadRuntime} from '@wonderlandengine/api';
 
 /* wle:auto-constants:start */
-const RuntimeOptions = {
-    physx: false,
-    loader: false,
-    xrFramebufferScaleFactor: 1,
-    canvas: 'canvas',
-};
 const Constants = {
     ProjectName: 'HeightMap',
     RuntimeBaseName: 'WonderlandRuntime',
     WebXRRequiredFeatures: ['local',],
     WebXROptionalFeatures: ['local','hand-tracking','hit-test',],
 };
+const RuntimeOptions = {
+    physx: false,
+    loader: false,
+    xrFramebufferScaleFactor: 1,
+    xrOfferSession: {
+        mode: 'auto',
+        features: Constants.WebXRRequiredFeatures,
+        optionalFeatures: Constants.WebXROptionalFeatures,
+    },
+    canvas: 'canvas',
+};
 /* wle:auto-constants:end */
+
+RuntimeOptions.threads = false; /* Disabled for testing on any browser */
+RuntimeOptions.simd = false;
 
 const engine = await loadRuntime(Constants.RuntimeBaseName, RuntimeOptions);
 
@@ -29,8 +37,14 @@ engine.registerComponent(WasdControlsComponent);
 engine.registerComponent(HeightMap);
 /* wle:auto-register:end */
 
+/* Remove them to avoid having the css animation pop during the screenshot */
 document.getElementById('version')?.remove();
 document.getElementById('ar-button')?.remove();
 document.getElementById('vr-button')?.remove();
 
-engine.scene.load(`${Constants.ProjectName}.bin`);
+await engine.loadMainScene({
+    url: `${Constants.ProjectName}.bin`,
+    waitForDependencies: true,
+    dispatchReadyEvent: false
+});
+/* No textures, event is dispatched after the heightmap generation */

--- a/matcap-shader/test/index.js
+++ b/matcap-shader/test/index.js
@@ -5,21 +5,30 @@ import {Rotate} from './../js/rotate.js';
 /* wle:auto-imports:end */
 
 import {loadRuntime} from '@wonderlandengine/api';
+import {runScreenshotTest} from '../../test-utils.js';
 
 /* wle:auto-constants:start */
-const RuntimeOptions = {
-    physx: false,
-    loader: false,
-    xrFramebufferScaleFactor: 1,
-    canvas: 'canvas',
-};
 const Constants = {
     ProjectName: 'MatcapShader',
     RuntimeBaseName: 'WonderlandRuntime',
     WebXRRequiredFeatures: ['local',],
     WebXROptionalFeatures: ['local','hand-tracking','hit-test',],
 };
+const RuntimeOptions = {
+    physx: false,
+    loader: false,
+    xrFramebufferScaleFactor: 1,
+    xrOfferSession: {
+        mode: 'auto',
+        features: Constants.WebXRRequiredFeatures,
+        optionalFeatures: Constants.WebXROptionalFeatures,
+    },
+    canvas: 'canvas',
+};
 /* wle:auto-constants:end */
+
+RuntimeOptions.threads = false; /* Disabled for testing on any browser */
+RuntimeOptions.simd = false;
 
 const engine = await loadRuntime(Constants.RuntimeBaseName, RuntimeOptions);
 
@@ -29,24 +38,13 @@ engine.registerComponent(WasdControlsComponent);
 engine.registerComponent(Rotate);
 /* wle:auto-register:end */
 
-await engine.scene.load(`${Constants.ProjectName}.bin`);
-
 document.getElementById('version')?.remove();
 document.getElementById('ar-button')?.remove();
 document.getElementById('vr-button')?.remove();
 
-/* Dispatch scene ready event once the image is loaded.
-    * This ensure the test suite takes a screenshot after
-    * all resources are available. */
-const promises = [new Promise((res) => setTimeout(res, 1000))];
-for (const img of engine.wasm._images) {
-    if (!(img instanceof HTMLImageElement)) continue;
-    if (img.complete) continue;
-    promises.push(new Promise((res, rej) => {
-        img.addEventListener('load', res, {once: true});
-        img.addEventListener('error', rej, {once: true});
-    }));
-}
-
-await Promise.all(promises);
-engine.scene.dispatchReadyEvent();
+await engine.loadMainScene({
+    url: `${Constants.ProjectName}.bin`,
+    waitForDependencies: true,
+    dispatchReadyEvent: false
+});
+runScreenshotTest(engine);

--- a/material-physical/test/index.js
+++ b/material-physical/test/index.js
@@ -1,20 +1,46 @@
 /* wle:auto-imports:start */
+import {MouseLookComponent} from '@wonderlandengine/components';
+import {WasdControlsComponent} from '@wonderlandengine/components';
+import {Generator} from './../js/generator.js';
 /* wle:auto-imports:end */
 
 import {loadRuntime} from '@wonderlandengine/api';
+import {runScreenshotTest} from '../../test-utils.js';
 
 /* wle:auto-constants:start */
+const Constants = {
+    ProjectName: 'MaterialPhysical',
+    RuntimeBaseName: 'WonderlandRuntime',
+    WebXRRequiredFeatures: ['local',],
+    WebXROptionalFeatures: ['local','hand-tracking','hit-test',],
+};
+const RuntimeOptions = {
+    physx: false,
+    loader: false,
+    xrFramebufferScaleFactor: 1,
+    xrOfferSession: {
+        mode: 'auto',
+        features: Constants.WebXRRequiredFeatures,
+        optionalFeatures: Constants.WebXROptionalFeatures,
+    },
+    canvas: 'canvas',
+};
 /* wle:auto-constants:end */
+
+RuntimeOptions.threads = false; /* Disabled for testing on any browser */
+RuntimeOptions.simd = false;
 
 const engine = await loadRuntime(Constants.RuntimeBaseName, RuntimeOptions);
 
 /* wle:auto-register:start */
+engine.registerComponent(MouseLookComponent);
+engine.registerComponent(WasdControlsComponent);
+engine.registerComponent(Generator);
 /* wle:auto-register:end */
 
-await engine.scene.load(`${Constants.ProjectName}.bin`);
-
-document.getElementById('version')?.remove();
-document.getElementById('ar-button')?.remove();
-document.getElementById('vr-button')?.remove();
-
-/* Event is dispatched in the generator.js component */
+await engine.loadMainScene({
+    url: `${Constants.ProjectName}.bin`,
+    waitForDependencies: true,
+    dispatchReadyEvent: false
+});
+runScreenshotTest(engine);

--- a/materials/test/index.js
+++ b/materials/test/index.js
@@ -4,21 +4,30 @@ import {WasdControlsComponent} from '@wonderlandengine/components';
 /* wle:auto-imports:end */
 
 import {loadRuntime} from '@wonderlandengine/api';
+import {runScreenshotTest} from '../../test-utils.js';
 
 /* wle:auto-constants:start */
-const RuntimeOptions = {
-    physx: false,
-    loader: false,
-    xrFramebufferScaleFactor: 1,
-    canvas: 'canvas',
-};
 const Constants = {
     ProjectName: 'Materials',
     RuntimeBaseName: 'WonderlandRuntime',
     WebXRRequiredFeatures: ['local',],
     WebXROptionalFeatures: ['local','hand-tracking','hit-test',],
 };
+const RuntimeOptions = {
+    physx: false,
+    loader: false,
+    xrFramebufferScaleFactor: 1,
+    xrOfferSession: {
+        mode: 'auto',
+        features: Constants.WebXRRequiredFeatures,
+        optionalFeatures: Constants.WebXROptionalFeatures,
+    },
+    canvas: 'canvas',
+};
 /* wle:auto-constants:end */
+
+RuntimeOptions.threads = false; /* Disabled for testing on any browser */
+RuntimeOptions.simd = false;
 
 const engine = await loadRuntime(Constants.RuntimeBaseName, RuntimeOptions);
 
@@ -27,17 +36,13 @@ engine.registerComponent(MouseLookComponent);
 engine.registerComponent(WasdControlsComponent);
 /* wle:auto-register:end */
 
-await engine.scene.load(`${Constants.ProjectName}.bin`);
-
 document.getElementById('version')?.remove();
 document.getElementById('ar-button')?.remove();
 document.getElementById('vr-button')?.remove();
 
-/* Dispatch scene ready event once the image is loaded.
- * This ensure the test suite takes a screenshot after
- * all resources are available.
- *
- * This example uses compressed images, and there is no current
- * API to listen for compressed images. */
-await new Promise((res) => setTimeout(res, 2000));
-engine.scene.dispatchReadyEvent();
+await engine.loadMainScene({
+    url: `${Constants.ProjectName}.bin`,
+    waitForDependencies: true,
+    dispatchReadyEvent: false
+});
+runScreenshotTest(engine);

--- a/postprocessing/test/index.js
+++ b/postprocessing/test/index.js
@@ -1,33 +1,48 @@
 /* wle:auto-imports:start */
+import {MouseLookComponent} from '@wonderlandengine/components';
+import {WasdControlsComponent} from '@wonderlandengine/components';
 /* wle:auto-imports:end */
 
 import {loadRuntime} from '@wonderlandengine/api';
+import {runScreenshotTest} from '../../test-utils.js';
 
 /* wle:auto-constants:start */
+const Constants = {
+    ProjectName: 'Postprocessing',
+    RuntimeBaseName: 'WonderlandRuntime',
+    WebXRRequiredFeatures: ['local',],
+    WebXROptionalFeatures: ['local','hand-tracking','hit-test',],
+};
+const RuntimeOptions = {
+    physx: false,
+    loader: false,
+    xrFramebufferScaleFactor: 1,
+    xrOfferSession: {
+        mode: 'auto',
+        features: Constants.WebXRRequiredFeatures,
+        optionalFeatures: Constants.WebXROptionalFeatures,
+    },
+    canvas: 'canvas',
+};
 /* wle:auto-constants:end */
+
+RuntimeOptions.threads = false; /* Disabled for testing on any browser */
+RuntimeOptions.simd = false;
 
 const engine = await loadRuntime(Constants.RuntimeBaseName, RuntimeOptions);
 
 /* wle:auto-register:start */
+engine.registerComponent(MouseLookComponent);
+engine.registerComponent(WasdControlsComponent);
 /* wle:auto-register:end */
-
-await engine.loadMainScene(`${Constants.ProjectName}.bin`);
-
-/* Find animation component, and stop them. */
-const stack = [...engine.scene.children];
-while (stack.length) {
-    const obj = stack.pop();
-    stack.push(...obj.children);
-
-    const animation = obj.getComponent('animation');
-    if (!animation) continue;
-
-    animation.stop();
-}
 
 document.getElementById('version')?.remove();
 document.getElementById('ar-button')?.remove();
 document.getElementById('vr-button')?.remove();
 
-await new Promise((res) => setTimeout(res, 500));
-engine.scene.dispatchReadyEvent();
+await engine.loadMainScene({
+    url: `${Constants.ProjectName}.bin`,
+    waitForDependencies: true,
+    dispatchReadyEvent: false
+});
+runScreenshotTest(engine);

--- a/test-utils.js
+++ b/test-utils.js
@@ -1,0 +1,48 @@
+/**
+ * Promise that resolves once:
+ * - Uncompressed textures are loaded
+ * - Texture streaming is stable
+ */
+export async function ready(engine) {
+    await engine.imagesPromise;
+    return new Promise((res) => {
+        engine.scene.onPostRender.add(function() {
+            if (!engine.isTextureStreamingIdle) return;
+            engine.scene.onPostRender.remove('texture-streaming-end');
+            res();
+        }, {
+            id: 'texture-streaming-end'
+        });
+    });
+}
+
+/**
+ * Pause all animations reference in a scene.
+ *
+ * @param scene The scene containing the animations to pause.
+ */
+export function pauseAnimations(scene) {
+    /* Find animation component, and stop them. */
+    const stack = [...scene.children];
+    while (stack.length) {
+        const obj = stack.pop();
+        stack.push(...obj.children);
+
+        const animation = obj.getComponent('animation');
+        if (!animation) continue;
+
+        animation.stop();
+    }
+}
+
+/**
+ * Dispatch the ready event once the application is ready.
+ *
+ * - Stops all animations
+ * - Waits for ready() to resolve
+ */
+export async function runScreenshotTest(engine) {
+    pauseAnimations(engine.scene);
+    await ready(engine);
+    engine.scene.dispatchReadyEvent();
+}


### PR DESCRIPTION
* Wait for uncompressed textures to be loaded in all examples
* Wait for textures.bin to be loaded in all examples
* Wait for texture streaming to idle, except in Heightmap example (ready once mesh is generated)
* Disable threads/simd when testing to:
    * Allow to run tests as-is in any browser
    * Wonderland builds release non-simd non-threads runtime as a priority