### PR TITLE
ci: Specify deploy job environment

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -67,6 +67,8 @@ jobs:
     needs: package
     if: ${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Seems to be required by deploy-pages@v4, see https://github.com/WonderlandEngine/wonderland-engine-examples/actions/runs/13415059974/job/37501059079