### PR TITLE
Add room capture functionality to PlaceShapeAnchor component

### DIFF
--- a/mixed-reality/js/place-shape-anchor.ts
+++ b/mixed-reality/js/place-shape-anchor.ts
@@ -107,7 +107,10 @@ export class PlaceShapeAnchor extends Component {
     private _launchedCapture: boolean = false;
 
     update(dt: number) {
-        if (!this.engine.xr?.frame) return;
+        if (!this.autoStartRoomCapture || !this.engine.xr?.frame) {
+            return;
+        }
+
         if (!this.engine.xr.frame.detectedPlanes) {
             console.error('plane-detection: WebXR feature not available.');
             this.active = false;
@@ -115,11 +118,7 @@ export class PlaceShapeAnchor extends Component {
         }
 
         if (this.engine.xr.frame.detectedPlanes.size === 0) {
-            if (
-                this._elapsedTime > this.roomCaptureDelay &&
-                !this._launchedCapture &&
-                this.autoStartRoomCapture
-            ) {
+            if (this._elapsedTime > this.roomCaptureDelay && !this._launchedCapture) {
                 if (this.engine.xr.frame.session.initiateRoomCapture) {
                     this.engine.xr.frame.session.initiateRoomCapture();
                 }

--- a/mixed-reality/js/place-shape-anchor.ts
+++ b/mixed-reality/js/place-shape-anchor.ts
@@ -75,6 +75,12 @@ export class PlaceShapeAnchor extends Component {
     @property.object()
     declare hitTestObject: Object3D;
 
+    @property.bool(true)
+    autoStartRoomCapture = true;
+
+    @property.float(5.0)
+    roomCaptureDelay = 5.0;
+
     private declare meshes: Mesh[];
     private declare materials: Material[];
     private declare cursor: Cursor;
@@ -95,6 +101,34 @@ export class PlaceShapeAnchor extends Component {
     onDeactivate(): void {
         this.cursor.hitTestTarget.onClick.remove(this.targetHit);
         this.cursor.globalTarget.onClick.remove(this.globalTargetHit);
+    }
+
+    private _elapsedTime: number = 0;
+    private _launchedCapture: boolean = false;
+
+    update(dt: number) {
+        if (!this.engine.xr?.frame) return;
+        if (!this.engine.xr.frame.detectedPlanes) {
+            console.error('plane-detection: WebXR feature not available.');
+            this.active = false;
+            return;
+        }
+
+        if (this.engine.xr.frame.detectedPlanes.size === 0) {
+            if (
+                this._elapsedTime > this.roomCaptureDelay &&
+                !this._launchedCapture &&
+                this.autoStartRoomCapture
+            ) {
+                if (this.engine.xr.frame.session.initiateRoomCapture) {
+                    this.engine.xr.frame.session.initiateRoomCapture();
+                }
+                this._launchedCapture = true;
+            } else {
+                this._elapsedTime += dt;
+            }
+            return;
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request enhances the `PlaceShapeAnchor` component to improve the user experience when using WebXR plane detection by automatically initiating room capture if no planes are detected after a configurable delay. The main changes introduce new properties for controlling this behavior and add logic to trigger room capture automatically.

Based on description and sample from https://developers.meta.com/horizon/documentation/web/webxr-mixed-reality/

**Automatic Room Capture Enhancements:**

* Added the `autoStartRoomCapture` boolean property (default `true`) to control whether room capture should start automatically if no planes are detected.
* Added the `roomCaptureDelay` float property (default `5.0`) to specify the delay (in seconds) before attempting to auto-start room capture. 
* Implemented an update method to track elapsed time and trigger `session.initiateRoomCapture()` after the specified delay if no planes are detected and auto-start is enabled. 